### PR TITLE
Rb3it updates

### DIFF
--- a/alcustoms.pyproj
+++ b/alcustoms.pyproj
@@ -126,9 +126,18 @@
     </Compile>
     <Compile Include="sql\objects\Table.py" />
     <Compile Include="sql\objects\Utilities.py" />
+    <Compile Include="sql\objects\versioning.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="sql\objects\View.py" />
     <Compile Include="sql\objects\__init__.py" />
     <Compile Include="sql\tests\objects\test_graphdb.py" />
+    <Compile Include="sql\tests\objects\test_utilities.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="sql\tests\objects\test_versioning.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="sql\tests\objects\__init__.py" />
     <Compile Include="tests\decorators.py">
       <SubType>Code</SubType>

--- a/alcustoms.pyproj
+++ b/alcustoms.pyproj
@@ -73,6 +73,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="filemodules.py" />
+    <Compile Include="flask.py" />
     <Compile Include="gaming\dice\regexdice.py" />
     <Compile Include="gaming\dice\__init__.py" />
     <Compile Include="gaming\util.py" />

--- a/methods.py
+++ b/methods.py
@@ -20,10 +20,24 @@ import secrets ## password_generator
 import xml.etree.ElementTree as ET ## parsenamespaces
 
 from alcustoms.subclasses import pairdict ## Timer
+from alcustoms.decorators import SignatureDecorator
+
+def _caststring(bargs):
+    """ Used to convert the first non-self arg for a function into a DotVersion
+        (by first casting as string and then to DotVersion). """
+    if bargs.args:
+        for k,v in bargs.arguments.items():
+            if k == "self": continue
+            break
+        try: v = DotVersion(str(v))
+        except: pass
+        else:
+            bargs.arguments[k] = v
 
 class DotVersion():
     """ A container class to allow for easy comparisons between versions with dot-dilineation (i.e.- 1.2.03.40) """
     _version = "0"
+    caststring_factory = SignatureDecorator.factory(_caststring)
     def expand(version):
         return [int(ver) for ver in version.split(".")]
     def __init__(self,version):
@@ -41,21 +55,42 @@ class DotVersion():
     @property
     def expanded(self):
         return DotVersion.expand(self.version)
+        
+    @caststring_factory
     def __eq__(self,other):
         if isinstance(other,DotVersion):
             for v1,v2 in itertools.zip_longest(self.expanded,other.expanded,fillvalue = 0):
                 if v1!=v2: return False
             return True
+    @caststring_factory
     def __lt__(self,other):
         if isinstance(other,DotVersion):
             for v1,v2 in itertools.zip_longest(self.expanded,other.expanded,fillvalue = 0):
                 if v1 < v2: return True
-            return True
+            return False
+        return NotImplemented
+    @caststring_factory
     def __le__(self,other):
         if isinstance(other,DotVersion):
             for v1,v2 in itertools.zip_longest(self.expanded,other.expanded,fillvalue = 0):
                 if v1 > v2: return False
             return True
+        return NotImplemented
+    def __gt__(self,other):
+        return not self <= other
+    def __ge__(self,other):
+        return not self < other
+    @caststring_factory
+    def __add__(self,other):
+        if isinstance(other,DotVersion):
+            out = []
+            for v1,v2 in itertools.zip_longest(self.expanded, other.expanded, fillvalue = 0):
+                out.append(str(v1+v2))
+            return DotVersion(".".join(out))
+    @caststring_factory
+    def __radd__(self,other):
+        return self + other
+
     def __hash__(self):
         return hash(str(self))
     def __str__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-requests
 bs4
-pillow
-openpyxl
-google
 flask
+google
 google-api-python-client
 matplotlib
+numpy
+openpyxl
+pillow
+requests

--- a/sql/objects/__init__.py
+++ b/sql/objects/__init__.py
@@ -368,6 +368,13 @@ class AdvancedRow():
         self.cursor = cursor
         self.row = dict_factory(cursor,row)
 
+    def drop(self):
+        """ Drops the row from it's Table.
+       
+            The row will not commit the change automatically.
+        """
+        self.table.quickdelete(pk = self.pk)
+
     def __getattribute__(self, name):
         ## Don't hijack reserved names or specific, known attrs (saves a couple steps)
         if name.startswith("__") or name in ['table','cursor','row']:

--- a/sql/objects/versioning.py
+++ b/sql/objects/versioning.py
@@ -1,0 +1,102 @@
+from .Connection import *
+from alcustoms.sql import Table, advancedrow_factory
+from .Utilities import temp_row_factory
+from alcustoms.methods import DotVersion
+
+VERSIONTABLE = "_versions"
+
+def createversiontable(db):
+    """ Creates a new version table and prepopulates it with 0-version tables """
+    db.execute(f"""
+CREATE TABLE {VERSIONTABLE} (
+    tablename TEXT NOT NULL REFERENCES sqlite_master(name),
+    version TEXT NOT NULL,
+    updatescript TEXT DEFAULT "",
+    rollbackscript TEXT DEFAULT ""
+);""")
+    tables = [table.name for table in db.getalltables()]
+    tablestrings = [f'(?,0.0,"","")' for table in tables]
+    db.execute(f"""
+INSERT INTO {VERSIONTABLE}
+(tablename,version,updatescript,rollbackscript) VALUES
+{','.join(tablestrings)};""",tables)
+
+class VersionMixin():
+    """ A Mixin to add a skeletal framework for versioning.
+    
+        Adds a "_versions" table which is prepopulated with existing tables.
+        Provides getversion for specifically accessing the table.
+        Hooks into Database.addtables to automatically add table versions.
+        Includes updateversion and rollbackversion methods to change versions for individual tables.
+    """
+    def __init__(self,*args,checkversion = None, default_version = "1.0", **kw):
+        """ VersionMixin initialization. Should be mixed into a Database class and should come before it.
+
+            checkversion is a callback to check that the database is up to date. The
+            callback should accept this object as its only positional argument.
+            default_version is used to set the version for any table added to the database
+            or prepopulated into the _versions table. Defaults to "1.0"
+
+            If _versions table does not exist, automatically creates and prepopulates it.
+        """
+        super().__init__(*args,**kw)
+        self.default_version = DotVersion(default_version)
+        if not self.tableexists(VERSIONTABLE):
+            createversiontable(self)
+        if checkversion:
+            try: checkversion(self)
+            except TypeError: raise TypeError("checkversion callback must be a callable")
+
+    def getversion(self,table):
+        """ Returns the version number for the given table """
+        if isinstance(table,Table.Table): table = table.name
+        if not isinstance(table,str): raise TypeError(f"table should be a string or a Table object, not {table.__class__.__name__}")
+
+        result = self.getadvancedtable(VERSIONTABLE).quickselect(tablename = table, columns = ["version",]).last()
+        if not result: raise Table.TableExistsError()
+        return DotVersion(result[0])
+
+    def updateversion(self,table, version = None, updatescript = None, rollbackscript = None):
+        if isinstance(table,Table.Table): table = table.name
+        if not isinstance(table,str): raise TypeError(f"table should be a string or a Table object, not {table.__class__.__name__}")
+
+        current = None
+        try: current = self.getversion(table)
+        except Table.TableExistsError: pass
+
+        if version is None:
+            if current: version = current + self.default_version
+            else: version = self.default_version
+        
+        if current and current >= version:
+            raise ValueError("Cannot Update version to a lower value than the current: rollback table before forking to a different version")
+
+        version = str(version)
+        self.getadvancedtable(VERSIONTABLE).addrow(tablename = table, version = version, updatescript = updatescript, rollbackscript = rollbackscript)
+
+        if updatescript:
+            self.executescript(updatescript)
+
+    def rollbackversion(self,table):
+        """ Rollsback a table to its previous version, executing a rollback script if available and removing the current version from the database.
+        
+            Returns the version row that was removed.
+        """
+        version = self.getversion(table)
+        with temp_row_factory(self,advancedrow_factory):
+            vtable = self.getadvancedtable(VERSIONTABLE)
+        row = vtable.quickselect(tablename = table, version = str(version)).first()
+        vtable.quickdelete(pk = row)
+        if row.rollbackscript:
+            self.executescript(row.rollbackscript)
+        return row
+
+    def addtables(self,*args,**kw):
+        success,fail = super().addtables(*args,**kw)
+        for table in success:
+            self.updateversion(table)
+        return success,fail
+
+class VersionedDatabase(VersionMixin,Database):
+    """ A simple implementation of the VersionMixin """
+    pass

--- a/sql/tests/objects/test_utilities.py
+++ b/sql/tests/objects/test_utilities.py
@@ -1,0 +1,43 @@
+from alcustoms.sql.objects import Utilities
+import unittest
+
+from alcustoms.sql import Database, Table, dict_factory
+import re
+
+class DropColumnCase(unittest.TestCase):
+    def setUp(self):
+        self.table = Table.Table("""CREATE TABLE a (a INTEGER, b TEXT);""")
+        self.db = Database(":memory:")
+    def test_match_text(self):
+        """ Checks for expected output string """
+        self.assertRegex(Utilities.generate_dropcolumn(self.table,"a"),re.compile("""BEGIN TRANSACTION;
+\s*CREATE TEMPORARY TABLE a__temporary__\(\s*b TEXT\s*\);\s*INSERT INTO a__temporary__ SELECT b FROM a;
+\s*DROP TABLE a;\s*CREATE TABLE a\(\s*b TEXT\s*\);\s*INSERT INTO a SELECT b FROM a__temporary__;
+\s*DROP TABLE a__temporary__;\s*COMMIT;""".replace(" ","\s+"),re.IGNORECASE | re.VERBOSE))
+
+    def test_dropcolumn(self):
+        """ Checks that string works """
+        self.db.addtables(self.table)
+        dropcol = Utilities.generate_dropcolumn(self.table,"a")
+        self.db.executescript(dropcol)
+        advtable = self.db.getadvancedtable("a")
+        self.assertEqual(len(advtable.columns),1)
+        self.assertIn("b", advtable.columns)
+        self.assertNotIn("a", advtable.columns)
+
+    def test_dataintegrity(self):
+        """ Makes sure that remaining columns have their correct values """
+        input = [{"a":i, "b":str(i*3)} for i in range(100)]
+        self.db.row_factory = dict_factory
+        self.db.addtables(self.table)
+        advtable = self.db.getadvancedtable("a")
+        advtable.addmultiple(*input)
+        self.assertEqual(advtable.selectall(), input)
+        dropcol = Utilities.generate_dropcolumn(self.table,"a")
+        self.db.executescript(dropcol)
+        advtable = self.db.getadvancedtable("a")
+        for i in input: del i['a']
+        self.assertEqual(advtable.selectall(), input)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sql/tests/objects/test_versioning.py
+++ b/sql/tests/objects/test_versioning.py
@@ -1,0 +1,112 @@
+import pathlib
+import unittest
+from alcustoms.sql import Database, Table, generate_dropcolumn
+from alcustoms.sql.objects.versioning import *
+
+class BasicCase(unittest.TestCase):
+    def setUp(self):
+        self.memdb = VersionedDatabase(":memory:")
+        return super().setUp()
+
+    def test_missing(self):
+        """ Tests that Databases without a _versions table automatically create one. """
+        self.assertEqual(len(self.memdb.getalltables()),1)
+        self.assertTrue(self.memdb.tableexists(VERSIONTABLE))
+
+        f = pathlib.Path("_______temp________.sqlite3test").resolve()
+        f.touch()
+        db = Database(f)
+        try:
+            db.execute("""CREATE TABLE blah(a);""")
+            db.close()
+        except Exception as e:
+            db.close()
+            f.unlink()
+            raise e
+        else:
+            db.close()
+        db = VersionedDatabase(f)
+        try:
+            self.assertTrue(db.tableexists(VERSIONTABLE))
+            self.assertEqual(len(db.getalltables()),2)
+        finally:
+            db.close()
+            f.unlink()
+
+    def test_getversion(self):
+        """ Tests the getversion function """
+        self.memdb.execute("""CREATE TABLE blah(a);""")
+        self.memdb.execute(f"""INSERT INTO {VERSIONTABLE} (tablename,version) VALUES ("blah","1.0");""")
+        self.assertEqual(self.memdb.getversion("blah"),"1.0")
+        self.memdb.execute(f"""UPDATE {VERSIONTABLE} SET version = "2.0" WHERE tablename = "blah";""")
+        table = self.memdb.getadvancedtable("blah")
+        self.assertEqual(self.memdb.getversion(table),"2.0")
+
+    def test_updateversion_basic(self):
+        """ Tests the updateversion function can add a version"""
+        self.memdb.execute("""CREATE TABLE blah(a);""")
+            
+        self.memdb.updateversion("blah","1.0")
+        self.assertEqual(self.memdb.getversion("blah"),"1.0")
+
+        table = self.memdb.getadvancedtable("blah")
+        self.memdb.updateversion(table,"2.0")
+        self.assertEqual(self.memdb.getversion(table),"2.0")
+
+    def test_updateversion_default_version(self):
+        """ Tests that when no version is provided, the default is added instead """
+        table = Table.Table("""CREATE TABLE blah(a);""")
+        self.memdb.addtables(table)
+        self.memdb.updateversion(table)
+        self.assertEqual(self.memdb.getversion(table),"2.0")
+        self.memdb.default_version = "0.1"
+        self.memdb.updateversion(table)
+        self.assertEqual(self.memdb.getversion(table),"2.1")
+
+    def test_addtable_hook(self):
+        """ Tests that Database.addtable is properly extended """
+        table = Table.Table("""CREATE TABLE blah(a);""")
+        success,fail = self.memdb.addtables(table)
+        self.assertEqual(len(success),1)
+        self.assertEqual(len(fail),0)
+        self.assertEqual(self.memdb.getversion(table),"1.0")
+
+        version = "12.34"
+        self.memdb.default_version = version
+        table = Table.Table("""CREATE TABLE foo(b);""")
+        self.memdb.addtables(table)
+        self.assertEqual(self.memdb.getversion(table),version)
+
+    def test_updateversion_updatescripts(self):
+        """ Tests that the database applies the update script and stores the update/rollbackscripts if they are supplied """
+        table = Table.Table("""CREATE TABLE blah(a);""")
+        self.memdb.addtables(table)
+
+        version,updatescript,rollbackscript = "2.0","""ALTER TABLE blah ADD COLUMN b TEXT;""",generate_dropcolumn(table,"b")
+        self.memdb.updateversion(table,version,updatescript,rollbackscript)
+
+        with temp_row_factory(self.memdb,advancedrow_factory):
+            versiontable = self.memdb.getadvancedtable(VERSIONTABLE)
+            stats = versiontable.quickselect(tablename=table.name, version = version).first()
+        self.assertEqual([stats.tablename.name,stats.version,stats.updatescript,stats.rollbackscript], [table.name,version,updatescript,rollbackscript])
+
+        table = self.memdb.getadvancedtable("blah")
+        self.assertEqual(len(table.columns),2)
+        self.assertIn('b',table.columns)
+
+    def test_rollback(self):
+        """ Tests that the database can use rollbackscript to rollback a table """
+        table = Table.Table("""CREATE TABLE blah(a);""")
+        self.memdb.addtables(table)
+        self.memdb.updateversion(table,"2.0","""ALTER TABLE blah ADD COLUMN b TEXT;""",generate_dropcolumn(table,"b"))
+
+        table = self.memdb.getadvancedtable("blah")
+        self.assertIn("b",table.columns)
+
+        self.memdb.rollbackversion("blah")
+        table = self.memdb.getadvancedtable("blah")
+        self.assertNotIn('b',table.columns)
+        self.assertEqual(self.memdb.getversion(table),"1.0")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sql/tests/test_sql.py
+++ b/sql/tests/test_sql.py
@@ -1432,6 +1432,16 @@ class AdvancedRowCase(unittest.TestCase):
         row = table.selectall().first()
         self.assertEqual(row.pk, row.userid)
 
+    def test_drop(self):
+        """ Tests that the advancedrow can drop itself. """
+        self.connection.row_factory = objects.advancedrow_factory
+        row = self.connection.getadvancedtable("users").quickselect(pk = 1).first()
+        self.assertTrue(row)
+        row.drop()
+        newrow = self.connection.getadvancedtable("users").quickselect(pk = 1).first()
+        self.assertFalse(newrow)
+        self.assertNotEqual(row,newrow)
+
 class QueryResultCase(unittest.TestCase):
     """ Tests for QueryResult Object and AdvancedTable functions that are decorated by its decorator """
     def setUp(self):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,9 +1,19 @@
-from alcustoms.methods import DotVersion
+from alcustoms.methods import DotVersion, _caststring
 import unittest
 
-""" DotVersion Class Tests """
+from alcustoms import decorators
+
+""" DotVersion Class Tests
+
+    DotVersion will probably be moved off into its own submodule eventually, so these tests are kept separate.
+"""
 class DotVersionCase(unittest.TestCase):
-    def test_all(self):
+    def test_creation(self):
+        self.assertIsInstance(DotVersion("1"),DotVersion)
+        self.assertEqual(DotVersion("2").version, "2")
+        self.assertEqual(DotVersion("3.4").expanded,[3,4])
+
+    def test_comparisons(self):
         """ A general series of tests of comparisons """
         self.assertEqual(DotVersion("1"), DotVersion("1"))
         self.assertLess( DotVersion("2.1") , DotVersion("2.2"))
@@ -29,7 +39,37 @@ class DotVersionCase(unittest.TestCase):
         except AssertionError: pass
         else:
             raise self.fail("Was expected to raise AssertionError")
+        self.assertEqual(DotVersion("1") + DotVersion("1"),DotVersion("2"))
+        self.assertEqual(DotVersion("1") + DotVersion("0.1"),DotVersion("1.1"))
+        self.assertEqual(DotVersion("1.2") + DotVersion("2.1"),DotVersion("3.3"))
+        self.assertNotEqual(DotVersion("9.0.0.1") + DotVersion("0.9.9.9"),DotVersion("10"))
+        self.assertEqual(DotVersion("9.0.0.1") + DotVersion("0.9.9.9"),DotVersion("9.9.9.10"))
 
+class StringIteroperabilityCase(unittest.TestCase):
+    def test_caststring(self):
+        
+        @decorators.signature_decorator_factory(_caststring)
+        def testfunc(val,is_isnot):
+            if is_isnot:
+                self.assertIsInstance(val,DotVersion)
+            else:
+                self.assertNotIsInstance(val,DotVersion)
+
+        testfunc("1",True)
+        testfunc("1.0",True)
+        testfunc(1,True)
+        testfunc(1.0,True)
+        testfunc("f",False)
+        testfunc("1...",False)
+
+
+    def test_comparisons(self):
+        self.assertEqual(DotVersion("1"),"1")
+        self.assertEqual("1",DotVersion("1"))
+        self.assertNotEqual(DotVersion("1"),"2")
+        self.assertNotEqual("1",DotVersion("2"))
+        self.assertGreater(DotVersion("2"),"1")
+        self.assertGreater(DotVersion("2.1"),"2")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Updates to `alcustoms.sql` and minor improvements to `methods.DotVersion` and `requirements.txt`:

- Added `drop()` method to `alcustoms.sql.AdvancedRow`
  - Allows an `AdvancedRow` to drop itself from its Table
- Added `generate_dropcolumn()` method to `alcustoms.sql.objects.Utilities`
  - Generates an SQL script that can be used to remove a column from the given table.
  - Script is based on sqlite FAQ example.
- Added `alcustoms.sql.objects.versioning`
  - This new module provides a Mixin to provide versioning capabilities to `Connection` objects
    - New versions can be registered alongside scripts for committing and rolling back the version
  - Includes a "vanilla" `Connection Object` for simple use cases: `VersionedDatabase`
- `alcustoms.methods.DotVersion` can be compared to `strings` directly (without having to initialize the them to new `DotVersion` instances)
- `requirements.txt` was alphabetized and verified for completeness 