### PR TITLE
Decorators Update

### DIFF
--- a/alcustoms.pyproj
+++ b/alcustoms.pyproj
@@ -145,7 +145,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="sql\tests\objects\__init__.py" />
-    <Compile Include="tests\decorators.py">
+    <Compile Include="tests\test_decorators.py">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="tests\test_alcustoms.py">


### PR DESCRIPTION
Rewrote and modified `decorators.batchable` and added `batchable_generator`. Renamed `tests.decorators.py` to `tests.test_decorators.py` and added tests.

### decorators
* `batchable()`- Now requires that the variable argument is specified as part of creating the decorator. Results now are returned as a list. The *callback* argument can be used to modify the output of `batchable`'s decorator before returning the final result.
* `batchable_generator()`- A generator version of batchable to allow for partial-resolution of  `batchable` functions. Stores the last *args* applied as `decorated_function._lastargs`.

### tests.decorators.py
* Renamed to `tests.test_decorators.py` as part of the continued refactoring and consistency effort.
* Added a `TestCase` for `batchable` (including tests for `batchable_generator` under the same case.