### PR TITLE
Fixed sql imports and added misc.

### DIFF
--- a/Programs/SQLExplorer.py
+++ b/Programs/SQLExplorer.py
@@ -45,7 +45,7 @@ def get_tags(obj,*tags):
         will be included.
         """
     tags = list(tags)
-    if isinstance(obj,sql.Table.Table):
+    if isinstance(obj,sql.Table):
         tags.append("table")
     elif isinstance(obj,sql.Column):
         tags.append("column")
@@ -280,7 +280,7 @@ class TreeController(advancedtkinter.Controller):
 
     def additem(self,object,parent):
         """ Adds the given object to the given parent """
-        if isinstance(object,sql.Table.Table): name = object.fullname
+        if isinstance(object,sql.Table): name = object.fullname
         elif isinstance(object,sql.Column): name = object.name
         elif isinstance(object,sql.Constraint): name = object.constraint
         else: name = "None"
@@ -324,7 +324,7 @@ class TreeController(advancedtkinter.Controller):
         sel = self.tree.selection(1)
         if sel in self.lookup:
             obj = self.lookup[sel]
-            if isinstance(obj,sql.Table.Table):
+            if isinstance(obj,sql.Table):
                 text = self.tree.item(sel,"text")
                 if text == SHOWMORE:
                     self.populaterows(sel)
@@ -375,7 +375,7 @@ class TreeController(advancedtkinter.Controller):
         rowvalue = self.getrowvalue(iid)
         for r_iid in self.tree.get_children(iid):
             ## SHOWMORE has a (Advanced)Table value in lookup
-            if r_iid in self.lookup and not isinstance(self.lookup[r_iid],sql.Table.Table):
+            if r_iid in self.lookup and not isinstance(self.lookup[r_iid],sql.Table):
                 self.tree.item(r_iid, text = self.lookup[r_iid][str(rowvalue)])
 
 class DescriptionController(advancedtkinter.Controller):

--- a/sql/__init__.py
+++ b/sql/__init__.py
@@ -1,3 +1,4 @@
+from sqlite3 import *
 from .newparser import Parser
 from . import objects
 

--- a/sql/objects/Connection.py
+++ b/sql/objects/Connection.py
@@ -8,6 +8,8 @@ import functools
 import pathlib
 from sqlite3 import *
 
+__all__ = ["Database",]
+
 ############################################
 """
              UTILITY FUNCTIONS

--- a/sql/objects/Table.py
+++ b/sql/objects/Table.py
@@ -6,6 +6,8 @@ from alcustoms.sql.objects import Connection, Utilities
 ## Builtin
 from collections import OrderedDict
 
+__all__ = ["TableExistsError","TableConstructor","Table","AdvancedTable",]
+
 class TableExistsError(ValueError):
     def __init__(self,*args,**kw):
         if not args: args = ["Table does not Exist",]

--- a/sql/objects/Utilities.py
+++ b/sql/objects/Utilities.py
@@ -1,6 +1,8 @@
 ## Builtin
 import functools
 
+__all__ = ["temp_row_factory","temp_row_decorator","generate_dropcolumn"]
+
 class temp_row_factory():
     """ A Context Manager for temporarily changing the row_factory of a connection or AdvancedTable instance
 

--- a/sql/objects/View.py
+++ b/sql/objects/View.py
@@ -12,6 +12,8 @@ from sqlite3 import OperationalError
 ## Builtin
 from collections import OrderedDict
 
+__all__ = []
+
 def getalltables(conn):
     """ Returns a list of Tables from a Database """
     sel = conn.execute("""SELECT * FROM sqlite_master

--- a/sql/objects/__init__.py
+++ b/sql/objects/__init__.py
@@ -13,6 +13,8 @@ from alcustoms.methods import isiterable
 ## This Module
 from alcustoms.sql.constants import *
 
+__all__ = ["QueryResult","dict_factory","object_to_factory","SQLColumn","AdvancedRow","advancedrow_factory","Advanced_RowID","Comment","MultilineComment","ColumnReference","Column","AdvancedColumn",]
+
 """ To enable parsing, set PARSER at the module-level (PARSER is set automatically to .NewParser.Parser """
 PARSER = None
 
@@ -93,7 +95,7 @@ def performreplacements(sqlstring,lookup):
     return reg.sub(replace,sqlstring)
 
 class ReplacementFactory():
-    """ A simple object that dynamically generatess variables that can be used for sql placeholders.
+    """ A simple object that dynamically generates variables that can be used for sql placeholders.
     
     I like this better to get around scoping than "counter,repl = getnextrepl(counter)"
     """

--- a/sql/objects/graphdb.py
+++ b/sql/objects/graphdb.py
@@ -57,8 +57,10 @@
 
 ## This Module
 from alcustoms.sql.objects.Connection import Database
-from alcustoms.sql import advancedrow_factory, AdvancedRow_Factory, AdvancedRow
+from alcustoms.sql.objects import advancedrow_factory, AdvancedRow_Factory, AdvancedRow
 from alcustoms.sql.objects.Utilities import temp_row_factory
+
+__all__ = ["GraphDB","Edge","Node",]
 
 class GraphDB(Database):
     """ An python/sqlite implementation of a Graph-structured database.

--- a/sql/tests/objects/__init__.py
+++ b/sql/tests/objects/__init__.py
@@ -14,7 +14,7 @@ class Advanced_RowIDCase(unittest.TestCase):
     """
     def setUp(self):
         self.db = sql.Database(":memory:")
-        self.db.addtables(sql.Table.Table("""CREATE TABLE test (a TEXT, b INT);"""), sql.Table.Table("""CREATE TABLE test2 (a INTEGER PRIMARY KEY AUTOINCREMENT, b INT);"""))
+        self.db.addtables(sql.Table("""CREATE TABLE test (a TEXT, b INT);"""), sql.Table("""CREATE TABLE test2 (a INTEGER PRIMARY KEY AUTOINCREMENT, b INT);"""))
         self.table1 = self.db.getadvancedtable("test")
         self.table2 = self.db.getadvancedtable("test2")
         return super().setUp()

--- a/sql/tests/objects/test_Connection.py
+++ b/sql/tests/objects/test_Connection.py
@@ -8,8 +8,8 @@ from alcustoms.sql.tests import utils
 
 ## Sister Modules
 from alcustoms import sql
-from alcustoms.sql import objects, Utilities
-from alcustoms.sql.objects import Table, View
+from alcustoms.sql import objects
+from alcustoms.sql.objects import Table, View, Utilities
 
 
 class DatabaseObjectCase(unittest.TestCase):

--- a/sql/tests/objects/test_Table.py
+++ b/sql/tests/objects/test_Table.py
@@ -1,5 +1,5 @@
 ## Test Target
-from alcustoms.sql import Table
+from alcustoms.sql.objects import Table
 
 ## Test Framework
 import unittest
@@ -9,7 +9,7 @@ from alcustoms.sql.tests import utils
 
 ## This module
 from alcustoms.sql import constants, objects
-from alcustoms.sql import Connection
+from alcustoms.sql.objects import Connection
 
 ## Builtin
 import collections

--- a/sql/tests/objects/test_graphdb.py
+++ b/sql/tests/objects/test_graphdb.py
@@ -41,7 +41,7 @@ class BasicCase(unittest.TestCase):
         """ Tests a basic, fresh initialization """
         db = graphdb.GraphDB(":memory:")
         ## Make sure GraphDB is a subclass of Database
-        self.assertIsInstance(db,sql.Connection.Database)
+        self.assertIsInstance(db,sql.Database)
 
         ## Check graphdb_edges
         table = db.gettable("graphdb_edges")

--- a/sql/tests/objects/test_utilities.py
+++ b/sql/tests/objects/test_utilities.py
@@ -6,7 +6,7 @@ import re
 
 class DropColumnCase(unittest.TestCase):
     def setUp(self):
-        self.table = Table.Table("""CREATE TABLE a (a INTEGER, b TEXT);""")
+        self.table = Table("""CREATE TABLE a (a INTEGER, b TEXT);""")
         self.db = Database(":memory:")
     def test_match_text(self):
         """ Checks for expected output string """

--- a/sql/tests/test_sql.py
+++ b/sql/tests/test_sql.py
@@ -142,7 +142,7 @@ class IdentifierCase(unittest.TestCase):
     def test_hashability(self):
         """ Tests that Identifiers are Hashable """
         lookup = dict(mycolumn=sql.Column("mycolumn",datatype="Text"))
-        self.assertIn(sql.Identifier.parse("mycolumn"),lookup)
+        self.assertIn(objects.Identifier.parse("mycolumn"),lookup)
 
 class ConflictClauseCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Various adjustments to the `sql` module.
#### General
* Added a proper `__all__` attribute to `alcustoms.sql` modules and fixed the affected imports within the module.
  * For `sql.object` modules `__all__` generally contains all of the Class objects; for other modules (including `objects.Utilities`) useful methods are included.
  * Obviously this will affect other modules that rely on `alcustoms.sql`
#### `sql.objects.versioning`
* Added a module docstring with usage example.
* Added a test for the example to make sure it worked.