### PR TITLE
alcustoms.math Update

### DIFF
--- a/alcustoms.pyproj
+++ b/alcustoms.pyproj
@@ -12,6 +12,7 @@
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <InterpreterId />
+    <TestFramework>unittest</TestFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
@@ -107,6 +108,18 @@
     <Compile Include="gtk\__init__.py" />
     <Compile Include="images.py" />
     <Compile Include="inspection.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="math\evaluator.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="math\tests\test_evaluator.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="math\tests\__init__.py">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="math\__init__.py">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="measurement.py">
@@ -248,7 +261,7 @@
     <Compile Include="tkinter\tkintersprites.py" />
     <Compile Include="tkinter\widgets.py" />
     <Compile Include="tkinter\__init__.py" />
-    <Compile Include="trig.py" />
+    <Compile Include="math\trig.py" />
     <Compile Include="web\bs4.py">
       <SubType>Code</SubType>
     </Compile>
@@ -284,6 +297,8 @@
     <Folder Include="gaming\dice" />
     <Folder Include="gtk" />
     <Folder Include="excel\" />
+    <Folder Include="math\" />
+    <Folder Include="math\tests\" />
     <Folder Include="text\" />
     <Folder Include="text\tests\" />
     <Folder Include="web\" />

--- a/math/__init__.py
+++ b/math/__init__.py
@@ -1,0 +1,4 @@
+""" alcustoms.math
+
+    Package of various Math-related modules
+"""

--- a/math/evaluator.py
+++ b/math/evaluator.py
@@ -1,0 +1,193 @@
+""" alcustoms.math.evaluator
+
+    A parser for string-based math springs.
+
+    The primary function of this module is math_eval() which does the evaluating.
+
+    Parsing Rules:
+        Basic Python operators are evaluated as normal: + , - , * , / , **
+        A collection of colliquial operators are supported (translated into Python): x (*) , ^ (**)
+        Multiline strings are supported for readablity, example:
+        \"""5*2
+            +
+            2/3\""" evaluates as "5*2+2/3"
+        Expanded Division is recognized for readibility using either backslash (/)
+            or multiple consecutive hyphens (-), example:
+        \"""2+3
+            [/ or -- (or more hyphens)]
+            5*6\""" evaluates as "(2+3)/(5*6)"
+"""
+
+import operator as op
+import re
+
+__all__ = ["math_eval",]
+
+TOKENNAMES = {
+    "openparens":"openparens",
+    "closeparens":"closeparens",
+    "numbers":"numbers",
+    "minus":"minus",
+    "expanddiv": "expanddiv",
+    "newline":"newline",
+    "add": op.add,
+    "mul": op.mul,
+    "div": op.truediv,
+    "exp": op.pow,
+    }
+MATHTOKENS = {
+    "\(":"openparens",
+    "\)":"closeparens",
+    "\d+(\.\d+)?":"numbers",
+    "\n[^\S\n]*(?:-{2,}|\/)\s*?\n":"expanddiv",
+    "\\n": "newline",
+    "\+": "add",
+    "\-": "minus",
+    "\/": "div",
+    "\^|\*\*": "exp",
+    "\*|x": "mul",
+    }
+TOKENSTRING = re.compile("\s*?(?:"+"|".join(f"(?P<{token}>{pattern})" for pattern,token in MATHTOKENS.items())+")")
+
+def math_eval(value):
+    """ Parses a string into a mathematical expression and evaluates it, returning a float. """
+    if not isinstance(value, (int,float,str)): raise TypeError(f"Invalid argument for math_eval; should be a string: {value}")
+    if isinstance(value,(int,float)): return value
+    stack = _create_stack(value,[])
+    return resolvestack(stack)
+
+def _create_stack(value, stack):
+    """ Recursively tokenizes a math string input appending to the given stack,
+        which should be a list (should be called initially with an empty list) """
+    if not value: return stack
+    if not (match := TOKENSTRING.search(value)):
+        ## Only non-newline whitespace is left
+        if not value.strip(): return stack
+        raise ValueError("Could not Parse value")
+    tokentype = match.lastgroup
+    operator = TOKENNAMES[tokentype]
+    text = match.group()
+    ## Handle numbers now, since they won't be preserved
+    if operator == "numbers":
+        operator = float(text)                    
+    stack.append(operator)
+    return _create_stack(value[len(text):],stack)
+
+def resolvestack(stack):
+    """ Resolves a math stack into a result """
+    ## Convert parens into nested lists
+    stack = _nest_parens(stack)
+    ## Converts Expanded Divisions into nested lists with normal divs
+    stack = _parse_expanddiv(stack)
+    ## Newlines no longer matter
+    stack = [e for e in stack if e!="newline"]
+    def recurse_resolve(stacksegment):
+        """ Recursively resolves stack segments """
+        ## Recurse nested lists first
+        stacksegment = [recurse_resolve(e) if isinstance(e,list) else e for e in stacksegment]
+        ## Resolve non-nested list
+        ## Resolve "minus" into negative inversion or subtraction
+        stacksegment = _resolve_minus(stacksegment)
+        ## Resolve Operators
+        for opers in [[op.pow,],[op.mul,op.truediv],[op.add,op.sub]]:
+            ## While there are any target operators in the stacksegment
+            ## record their index
+            while operin := [stacksegment.index(oper) for oper in opers if oper in stacksegment]:
+                ## resolve first occuring operator
+                i = min(operin)
+                ## Operators should not be the first element
+                if i == 0: raise SyntaxError(f"Could not resolve stack segment: {stacksegment}")
+                try:
+                    head,[a,operation,b],tail = stacksegment[:i-1],stacksegment[i-1:i+2],stacksegment[i+2:]
+                    result = operation(a,b)
+                except:
+                    raise SyntaxError(f"Could not resolve operation at index {i}: {stacksegment}")
+                else:
+                    stacksegment = head + [result,] + tail
+        if len(stacksegment) != 1: raise SyntaxError(f"Unresolved stack segment: {stacksegment}")
+        return stacksegment[0]
+
+    return recurse_resolve(stack)
+        
+def _nest_parens(stacksegment):
+    """ Converts Parens into nested lists (stack segments) """
+    def recurse_parens(stacksegment):
+        """ Recursive part of nest_parens (once an opening parens if found)"""
+        ci,oi = False,False
+        ## Check for first occurence opening and closing parens
+        if "closeparens" in stacksegment: ci = stacksegment.index("closeparens")
+        if "openparens" in stacksegment: oi = stacksegment.index("openparens")
+        ## Since this function relies on an opening parens, a closing parens is required
+        if ci is False: raise SyntaxError("Unpaired Open Parentheses")
+        ## Closing parens comes before next Opening (or Opening does not exist)
+        if oi is False or ci < oi:
+            nest, tail = stacksegment[:ci],stacksegment[ci+1:]
+            return [nest,]+tail
+        ## If another Opening Parens is found first, handle it
+        else:
+            stacksegment,nest = stacksegment[:oi],recurse_parens(stacksegment[oi+1:])
+            stacksegment.extend(nest)
+            ## Recurse to continue with current level
+            return recurse_parens(stacksegment)
+
+    while "openparens" in stacksegment:
+        i = stacksegment.index("openparens")
+        ## Split list on open parens and recursively resolve it
+        stacksegment,result = stacksegment[:i],recurse_parens(stacksegment[i+1:])
+        ## Add result (nest and tail) back into segment
+        ## nest should not contain parens, but tail may
+        stacksegment.extend(result)
+
+    if "closeparens" in stacksegment:
+        raise SyntaxError("Unpaired Close Parentheses")
+
+    return stacksegment
+
+def _parse_expanddiv(stacksegment):
+    """ Parses expanded division tokens """
+    while "expanddiv" in stacksegment:
+        i = stacksegment.index("expanddiv")
+        reverse_subseg, tail = stacksegment[:i][::-1],stacksegment[i+1:]
+        if "newline" in reverse_subseg:
+            ni = reverse_subseg.index("newline")
+            num, head = reverse_subseg[:ni][::-1],reverse_subseg[ni:][::-1]
+        else:
+            num,head = stacksegment[:i],[]
+        if not num:
+            seg = "".join(stacksegment)
+            raise ValueError("Could not parse expanded div in stacksegment:{seg}")
+        ## Check for newline and expanddiv in tail to use as a breakpoint for the divisor
+        ## Get first index for each breakpoints
+        if bi := [tail.index(breaker) for breaker in ["newline","expanddiv"] if breaker in tail]:
+            ## Use earliest breakpoint
+            bi = min(bi)
+            denom,tail = tail[:bi],tail[bi:]
+        else:
+            denom,tail = tail,[]
+        if not denom:
+            seg = "".join(stacksegment)
+            raise ValueError("Could not parse expanded div in stacksegment:{seg}")
+        stacksegment = head + [num, op.truediv, denom] + tail
+    return stacksegment
+
+def _resolve_minus(stacksegment):
+    """ Intuits whether "minus" is a negative or subtraction """
+    while "minus" in stacksegment:
+        i = stacksegment.index("minus")
+        if i == 0:
+            if len(stacksegment) == 1 or not isinstance(stacksegment[1],float):
+                raise SyntaxError(f"Could not parse unary '-' in segment: {stacksegment}")
+            ## Leading negative and next number is float
+            stacksegment = stacksegment[1:]
+            stacksegment[0]*=-1
+            continue
+        ## Math Op before minus
+        if not isinstance(stacksegment[i-1],float):
+            ## Remove negative
+            stacksegment.pop(i)
+            ## The following float (now in the negative's index) is inverted
+            stacksegment[i] *= -1
+            continue
+        ## Previous element was float, which means this is Subtraction
+        stacksegment[i] = op.sub
+    return stacksegment

--- a/math/tests/__init__.py
+++ b/math/tests/__init__.py
@@ -1,0 +1,12 @@
+""" alcustoms.math.tests
+
+    Unittest files for alcustoms.math
+"""
+
+if __name__ == "__main__":
+    import unittest
+    import pathlib
+
+    path = pathlib.Path.cwd()
+    tests = unittest.TestLoader().discover(path)
+    unittest.TextTestRunner().run(tests)

--- a/math/tests/test_evaluator.py
+++ b/math/tests/test_evaluator.py
@@ -1,0 +1,126 @@
+""" alcustoms.math.tests.test_evaluator
+
+    Unittest Cases for alcustoms.math.evaluator
+"""
+## Test Target
+from alcustoms.math import evaluator
+## Test Framework
+import unittest
+## Builtin
+import operator as op
+
+
+class MathEvalCase(unittest.TestCase):
+    """ Tests the matheval function and helpers """
+    ## Shared tests for functions
+    TESTS = [
+"""1+2""", ## Standard
+"""1+2*3/12""", ## All Operations
+"""2x4""", ## Colloquial Multiplication
+"""-2*-1/-4-1""", ## Unary -
+"""  1  + 4 """, ## Whitespace
+"""
+14
+    +
+8""",      ## New Lines
+## parens,
+"""-8*4
+----
+2
+* 15""" ## Expanded Div
+]
+
+    def test_create_stack(self):
+        """ General _create_stack test """
+        RESULTS = [
+            [1.0,op.add,2.0],
+            [1.0,op.add,2.0,op.mul,3.0,op.truediv,12.0],
+            [2.0,op.mul,4.0],
+            ["minus",2.0,op.mul,"minus",1.0,op.truediv,"minus",4.0,"minus",1.0],
+            [1.0,op.add,4.0],
+            ["newline",14.0,"newline",op.add,"newline",8.0],
+            ["minus",8.0,op.mul,4.0,"expanddiv",2.0,"newline",op.mul,15.0]
+            ]
+        for test,result in zip(MathEvalCase.TESTS,RESULTS):
+            with self.subTest(test = test, result = result):
+                self.assertEqual(evaluator._create_stack(test,[]),result)
+
+    def test_nest_parens(self):
+        """ General _nest_parens test"""
+        TEST = [
+            ("1",[1.0]),
+            ("(12)", [[12.0],]),
+            ("(1+(2*3))",[ [1.0, op.add, [2.0,op.mul,3.0] ], ]),
+            ("(1+2)*(3+4)",[ [1.0,op.add,2.0], op.mul, [3.0,op.add,4.0] ])
+            ]
+        for test,result in TEST:
+            with self.subTest(test = test, result = result):
+                stack = evaluator._create_stack(test,[])
+                self.assertEqual(evaluator._nest_parens(stack),result)
+
+    def test_parse_expanddiv(self):
+        """ General _parse_expanddiv test """
+        TESTS = [
+            ("""1""",[1.0]),
+            ("""1
+            /
+            2
+            """, [ [1.0,],op.truediv,[2.0,], "newline"]), ## "1/2"
+            ("""4*5
+            -----
+            3""", [ [4.0,op.mul,5.0],op.truediv,[3,] ]), ## (4*5)/3
+            ("""
+            3*3
+            /
+            4/5
+            ---------
+            32/6""", [ "newline", [ [3.0,op.mul,3.0], op.truediv, [4.0,op.truediv,5.0] ], op.truediv, [32.0, op.truediv,6.0] ]),
+            ## ( (3*3)/(4/5) ) / (32/6)
+            ]
+        for test,result in TESTS:
+            with self.subTest(test = test, result = result):
+                stack = evaluator._create_stack(test,[])
+                stack = evaluator._nest_parens(stack)
+                self.assertEqual(evaluator._parse_expanddiv(stack),result)
+
+    def test_resolve_minus(self):
+        """ General _resolve_minus test """
+        TESTS = [
+            ([1.0,],[1.0,]),
+            (["minus",2.0],[-2.0,]),
+            ([3.0,"minus",4.0],[3.0,op.sub,4.0]),
+            ([5.0,op.mul,"minus",6.0],[5.0,op.mul,-6.0]),
+            ]
+        for test,result in TESTS:
+            with self.subTest(test = test, result = result):
+                self.assertEqual(evaluator._resolve_minus(test),result)
+
+    def test_matheval(self):
+        """ General matheval test """
+        RESULTS = [3.0, 1.5, 8.0, -1.5,5.0,22.0,-240.0]
+        for test,result in zip(MathEvalCase.TESTS,RESULTS):
+            with self.subTest(test = test, result = result):
+                self.assertEqual(evaluator.math_eval(test),result)
+
+class MathEvalCase2(unittest.TestCase):
+    """ More tests to try to break it (math_eval only)"""
+    TESTS = [
+        ("1",1),
+        ("""1*2*(1+3)/4**2""",0.5),
+        ("""4
+        -
+        3
+        /
+        5**2   +\t14
+        --
+        -2
+        -(3-5)
+        """,6.038461538461538),
+]
+    def test_math_eval(self):
+        for test,result in MathEvalCase2.TESTS:
+            with self.subTest(test = test, result = result):
+                self.assertEqual(evaluator.math_eval(test),result)
+                
+if __name__ == "__main__":
+    unittest.main()

--- a/math/trig.py
+++ b/math/trig.py
@@ -1,4 +1,18 @@
+""" alcustoms.math.trig
+
+    Contains various Trigonometry-based equations and helper functions
+"""
+## builtin
 import math
+import functools
+## Sister module
+from alcustoms.decorators import unitconversion_decorator_factory
+
+as_degrees = unitconversion_decorator_factory(math.degrees)
+as_degrees.__doc__ = "A helper-wrapper to automatically convert an argument to degrees.\n" + as_degrees.__doc__
+
+as_radians = unitconversion_decorator_factory(math.radians)
+as_radians.__doc__ = "A helper-wrapper to automatically convert an argument to radians.\n"+as_radians.__doc__
 
 def getcircumradiusofshape(points,sidelen):
     """ Returns the radius of a circle for the given number of points of an equilateral shape with the given sidelength """

--- a/methods.py
+++ b/methods.py
@@ -987,7 +987,7 @@ def pprinttypes(item,level = 0):
             children.append(printtypes(v,level+1))
     return out+ "\n" + "\n".join(children)
 
-if __name__=='__main__':
+if __name__== '__main__':
     pass
     ##### getstringformatting Test
     #teststring=['The {string}','This is {{Not a String}}']

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ numpy
 openpyxl
 pillow
 requests
+pywin32
+python-hosts

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -177,5 +177,34 @@ class SignatureDecoratorCase(unittest.TestCase):
         self.assertFalse(self.ranFlag)
         self.assertEqual(result, "bar")
 
+class UnitConversion_DFCase(unittest.TestCase):
+    """ Test Case for the unitconversion_decorator_factory function """
+    def test_deco(self):
+        """ Basic tests for the function """
+        ## Function that will be decorated
+        def my_test(a, b):
+            return a,b
+        ## Factory result
+        to_float_decorator = decorators.unitconversion_decorator_factory(float)
+        ## Test Values
+        argvals = [
+            (None,["1",1.0]), ## The first arg will be converted because None
+            ("a",["3.14",1.0]), ## The first arg will be converted by name
+            (1, [1.0, "2.71828"]), ## The second arg will be converted by index
+            ([0,"b"],["1.61803398875","0.8346268"]), ## A list of args, converting first arg by index and second by name
+            ]
+        for arg,testargs in argvals:
+            with self.subTest(arg = arg, testargs = testargs):
+                ## Normally written:
+                ## @to_float_decorator(arg)
+                ## def mytest(a,b): [... etc]
+                decorated = to_float_decorator(arg)(my_test)
+
+                a,b = decorated(*testargs)
+                self.assertIsInstance(a,float)
+                self.assertIsInstance(b,float)
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -203,6 +203,5 @@ class TimerCase(unittest.TestCase):
         self.assertEqual(timer.duration_dict("%S"),dict(seconds=5))
         self.assertEqual(timer.duration(),"0:0:5")
 
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Introduced the `alcustoms.math` package and some supporting functions:
### `alcustoms.math`
* A collection of math-related modules

### `math.trig`
* Moved `alcustoms.trig` to alcustoms.math.trig`
* Added the decorator factories `as_degrees` and `as_radians` which are products of the new `alcustoms.decorators.unitconversion_decorator_factory`

### `math.evaluator`
* A new module to contain `math_eval` and it supporting code
* `math_eval()` is a function to parse mathematical strings, with support for pretty-formatted and non-Python operator styles

### `math.tests.test_evaluator`
* Unittests for `math.evaluators`

### `decorators`
* Added `unitconversion_decorator_factory` which is an extension of `signature_decorator_factory` and produces a decorator factory to manipulate arguments of functions

### `tests.test_decorators`
* Added a `TestCase` for `unitconversion_decorator_factory`